### PR TITLE
Fix to MDC placeholders in log message

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 camel.springboot.main-run-controller = true
 
-logging.pattern.console = %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m traceId=%X{traceId} spanId=%X{spanId} %n%wEx
+logging.pattern.console = %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m traceId=%X{trace_id} spanId=%X{span_id} %n%wEx
 
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter = DEBUG
 logging.level.io.opentelemetry = DEBUG


### PR DESCRIPTION
The trace id and span id were not appearing in the logging due to the . This is because (per the [Camel docs](https://camel.apache.org/components/latest/others/opentelemetry.html)) the correct placeholders to use are `trace_id` and `span_id`.
These do appear to differ from the usual OpenTelemetry ones of `traceId` and `spanId` (note the missing underscore).